### PR TITLE
Fix to prevent secrets leakage

### DIFF
--- a/manifests/request.pp
+++ b/manifests/request.pp
@@ -129,7 +129,6 @@ define acme::request (
 
   # Convert the Hash to an Array, required for Exec's "environment" attribute.
   $hook_params = $_hook_params.map |$key,$value| { "${key}=${value}" }
-  notify { "hook params for cert ${name}: ${hook_params}": loglevel => debug }
 
   # Collect additional options for acme.sh.
   if ($profile['options']['dnssleep'] and ($profile['options']['dnssleep'] =~ Integer)

--- a/manifests/request.pp
+++ b/manifests/request.pp
@@ -210,7 +210,6 @@ define acme::request (
 
   # Convert days to seconds for openssl...
   $renew_seconds = $renew_days*86400
-  notify { "acme renew set to ${renew_days} days (or ${renew_seconds} seconds) for cert ${name}": loglevel => debug }
 
   # NOTE: If the CSR file is newer than the cert, this check will trigger
   # a renewal of the cert. However, acme.sh may not recognize the change


### PR DESCRIPTION
To prevent secret leakage in Puppetboard for example, we have to remove not needed notify:
![bug](https://github.com/markt-de/puppet-acme/assets/50769263/8035dc37-e686-4208-bbc1-adf73df17217)

Also see https://github.com/markt-de/puppet-acme/issues/49